### PR TITLE
Fix docs failing in GA

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,7 @@
 -i https://pypi.org/simple
+cryptography==3.4.8
+voluptuous==0.12.2
+
 alabaster==0.7.12
 babel==2.10.3; python_version >= '3.6'
 certifi==2022.6.15; python_version >= '3.6'

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,11 +1,27 @@
 -i https://pypi.org/simple
-voluptuous==0.11.7
-cryptography==3.3.2
-sphinx-rtd-theme==0.4.3
-sphinx==2.2.1
-sphinxcontrib-applehelp==1.0.1
-sphinxcontrib-devhelp==1.0.1
-sphinxcontrib-htmlhelp==1.0.2
-sphinxcontrib-jsmath==1.0.1
-sphinxcontrib-qthelp==1.0.2
-sphinxcontrib-serializinghtml==1.1.3
+alabaster==0.7.12
+babel==2.10.3; python_version >= '3.6'
+certifi==2022.6.15; python_version >= '3.6'
+charset-normalizer==2.1.0; python_version >= '3.6'
+docutils==0.17.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+idna==3.3; python_version >= '3.5'
+imagesize==1.4.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+importlib-metadata==4.12.0; python_version < '3.10'
+jinja2==3.1.2; python_version >= '3.7'
+markupsafe==2.1.1; python_version >= '3.7'
+packaging==21.3; python_version >= '3.6'
+pygments==2.12.0; python_version >= '3.6'
+pyparsing==3.0.9; python_full_version >= '3.6.8'
+pytz==2022.1
+requests==2.28.1; python_version >= '3.7' and python_version < '4'
+snowballstemmer==2.2.0
+sphinx-rtd-theme==1.0.0
+sphinx==5.0.2
+sphinxcontrib-applehelp==1.0.2; python_version >= '3.5'
+sphinxcontrib-devhelp==1.0.2; python_version >= '3.5'
+sphinxcontrib-htmlhelp==2.0.0; python_version >= '3.6'
+sphinxcontrib-jsmath==1.0.1; python_version >= '3.5'
+sphinxcontrib-qthelp==1.0.3; python_version >= '3.5'
+sphinxcontrib-serializinghtml==1.1.5; python_version >= '3.5'
+urllib3==1.26.10; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_version < '4'
+zipp==3.8.1; python_version >= '3.7'


### PR DESCRIPTION
In this commit we update the packages of sphinx
and sphinx-rtd-theme to resolve a package
dependency issue that caused the building of the
docs to fail.
The docs/requirements.txt file was generated by
creating a virtual env and installing only
sphinx and sphinx-rtd-theme and the running
pipenv lock -r to get the requirements and copy
paste them into the docs/requirements.txt.

Fixes #73