### PR TITLE
Add pre-commit tool

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
         name: coverage
         fail_ci_if_error: true
 
-    - name: Install docs dependecies
+    - name: Install docs dependencies
       run: pip install -r docs/requirements.txt
 
     - name: Run Docs tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+    -   id: check-added-large-files
+    -   id: end-of-file-fixer
+        files: 'ownca/'
+    -   id: trailing-whitespace
+        files: 'ownca/'
+    -   id: check-yaml
+        files: '.github/'
+-   repo: https://github.com/pycqa/flake8
+    rev: '4.0.1'
+    hooks:
+    -   id: flake8
+        exclude: ownca/__init__.py|venv|.venv|setting.py|.git|.tox|dist|docs|/*lib/python*|/*egg|build|tools

--- a/README.md
+++ b/README.md
@@ -66,3 +66,13 @@ In case you have macOS M1:
 pip uninstall cryptography cffi
 LDFLAGS=-L$(brew --prefix libffi)/lib CFLAGS=-I$(brew --prefix libffi)/include pip install cffi cryptography rust --no-binary :all:
 ```
+
+Installing & enabling pre-commit
+---------------------
+
+To automatically run checks before you commit your changes you should install and run **pre-commit**:
+```shell
+pip install pre-commit
+pre-commit install
+pre-commit autoupdate
+```

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,16 @@
 [tox]
-envlist = py37,py38,py39,,py310,pep8,integrations
+envlist = py37,py38,py39,,py310,lint,integrations
 
 [flake8]
 exclude = ownca/__init__.py,venv,.venv,settings.py,.git,.tox,dist,docs,*lib/python*,*egg,build,tools
+
+[testenv:lint]
+deps = pre-commit
+commands = pre-commit run --all-files --show-diff-on-failure
+
 [testenv:pep8]
-commands = flake8
+deps = {[testenv:lint]deps}
+commands = pre-commit run flake8 --all-files --show-diff-on-failure
 
 [testenv]
 deps = -r{toxinidir}/requirements.txt


### PR DESCRIPTION
In this commit, we add the pre-commit tool to
improve the Software Development Lifecycle
of the project by automatically running checks
(linting & formatting) before one commits their
changes.

Specifically:
- flake8 was adjusted in tox to run as a
pre-commit hook.

- Additionally, added hooks were:
* the check-added-large-files - prevents giant
files from being committed
* end-of-file-fixer - ensures that a file is either
empty, or ends with one newline
* trailing-whitespace - trims trailing
whitespace
* check-yaml - checks yaml files for parseable
syntax

- We updated the README.md with
how to install and enable pre-commit

- Fixed small typo in tests.yml